### PR TITLE
Optimize search terms analysis performance

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -234,7 +234,7 @@ def _max_parallel_requests() -> int:
 
 
 def _relevancy_chunk_size() -> int:
-    default_size = 50
+    default_size = 20
     raw = os.getenv("OPENAI_RELEVANCY_CHUNK_SIZE")
     if not raw:
         return default_size


### PR DESCRIPTION
## Summary
- Reduce default chunk size from 50 to 20 search terms per request to enable more parallel LLM calls
- Parallelize landing page analysis using ThreadPoolExecutor instead of sequential processing
- Expected to reduce analysis time from ~3 minutes to under 1.5 minutes for 1.3k search terms

## Test Plan
- [ ] Test with 1.3k search terms to verify performance improvement
- [ ] Verify quality of analysis results remains the same
- [ ] Check that parallel page analysis completes without errors
- [ ] Monitor LLM API rate limits

Fixes #41

🤖 Generated with [Claude Code](https://claude.ai/code)