### PR TITLE
Fix oversized background gradients on high-resolution displays

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,8 +17,8 @@
     />
     <style>
       body {
-        background: radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 55%),
-          radial-gradient(circle at bottom, rgba(14, 165, 233, 0.08), transparent 45%),
+        background: radial-gradient(circle 400px at top, rgba(59, 130, 246, 0.12), transparent 55%),
+          radial-gradient(circle 400px at bottom, rgba(14, 165, 233, 0.08), transparent 45%),
           #f8fafc;
         font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       }


### PR DESCRIPTION
## Summary
- Fixed massive background gradients appearing as oversized icons on high-resolution displays
- Added explicit 400px radius constraints to radial gradients in base.html

Fixes #54

🤖 Generated with [Claude Code](https://claude.ai/code)