### PR TITLE
Fix oversized background gradient causing UI issue

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,8 +17,8 @@
     />
     <style>
       body {
-        background: radial-gradient(circle 400px at top, rgba(59, 130, 246, 0.12), transparent 55%),
-          radial-gradient(circle 400px at bottom, rgba(14, 165, 233, 0.08), transparent 45%),
+        background: radial-gradient(circle 600px at top center, rgba(59, 130, 246, 0.08), transparent 60%),
+          radial-gradient(circle 500px at bottom right, rgba(14, 165, 233, 0.04), transparent 50%),
           #f8fafc;
         font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       }


### PR DESCRIPTION
Fixes the large black circle appearing at the bottom of the campaigns page.

## Changes
- Repositioned bottom radial gradient to bottom-right corner
- Reduced opacity from 0.08 to 0.04
- Adjusted gradient sizes and fade points for better visual balance

Resolves #61

Generated with [Claude Code](https://claude.ai/code)