### PR TITLE
Fix huge icon sizing issue

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,10 +11,7 @@
       rel="stylesheet"
     />
     <script src="https://unpkg.com/htmx.org@1.9.12" integrity="sha384-gH1jvRjjXNMTvEihQ/HUkNzxaz2YsmiVjCwXTlzAIXazhbugzuDUFc1l1YieYdGf" crossorigin="anonymous"></script>
-    <link
-      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css"
-      rel="stylesheet"
-    />
+    <script src="https://cdn.tailwindcss.com"></script>
     <style>
       body {
         background: radial-gradient(circle 600px at top center, rgba(59, 130, 246, 0.08), transparent 60%),


### PR DESCRIPTION
Fixes #63

### Summary
Fixed the huge icon sizing issue by correcting the Tailwind CSS CDN URL in `base.html`. The previous URL was not serving Tailwind CSS properly, causing all utility classes to not apply, which resulted in SVG icons rendering at their default sizes instead of the intended sizes.

### Changes
- Replaced incorrect `cdn.jsdelivr.net` URL with official Tailwind CSS Play CDN
- All icons throughout the app will now display at proper sizes

Generated with [Claude Code](https://claude.ai/code)