### PR TITLE
Fix icon sizing issue in analyze page

### DIFF
--- a/app/templates/analyze.html
+++ b/app/templates/analyze.html
@@ -46,23 +46,23 @@
           <div class="flex items-center gap-3 text-slate-700">
             <div class="flex-shrink-0 h-8 w-8 flex items-center justify-center">
               {% if step.icon == "🌐" %}
-              <svg class="flex-shrink-0 h-8 w-8 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg class="w-full h-full text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
               </svg>
               {% elif step.icon == "📥" %}
-              <svg class="flex-shrink-0 h-8 w-8 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg class="w-full h-full text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
               </svg>
               {% elif step.icon == "🧮" %}
-              <svg class="flex-shrink-0 h-8 w-8 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg class="w-full h-full text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
               </svg>
               {% elif step.icon == "🤖" %}
-              <svg class="flex-shrink-0 h-8 w-8 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg class="w-full h-full text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
               </svg>
               {% elif step.icon == "✅" %}
-              <svg class="flex-shrink-0 h-8 w-8 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg class="w-full h-full text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               {% else %}


### PR DESCRIPTION
This PR fixes the oversized icon issue in the analyze page timeline cards.

## Changes
- Modified SVG icon sizing from fixed `h-8 w-8` to `w-full h-full`
- Icons now properly fill their 32px parent containers
- Eliminates redundant sizing constraints

Fixes #67

Generated with [Claude Code](https://claude.ai/code)