### PR TITLE
Fix missing endblock tag in analyze.html template

### DIFF
--- a/app/templates/analyze.html
+++ b/app/templates/analyze.html
@@ -277,3 +277,5 @@
   updateHighlights();
 </script>
 {% endblock %}
+
+{% endblock %}


### PR DESCRIPTION
Fixes #73

This PR resolves the Jinja2 template syntax error in `analyze.html` by adding the missing `{% endblock %}` tag to properly close the `{% block content %}` block.

### Changes
- Added closing `{% endblock %}` tag at the end of `app/templates/analyze.html`

Generated with [Claude Code](https://claude.ai/code)