### PR TITLE
Add comprehensive logging to trace landing page analysis hang

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -168,6 +168,7 @@ def _temperature_kwargs(model: str, desired: float | None) -> dict[str, float]:
 @_openai_retry()
 def generate_page_summary(page: PageContent) -> str:
     """Create a compact landing-page summary using the LLM."""
+    logger.info("Starting generate_page_summary for %s", page.url)
     client = _get_openai_client()
     prompt = {
         "url": page.url,
@@ -180,6 +181,7 @@ def generate_page_summary(page: PageContent) -> str:
     }
     start = time.perf_counter()
     model = _model_name()
+    logger.info("Calling OpenAI API with model %s for %s", model, page.url)
     response = client.chat.completions.create(
         model=model,
         messages=[
@@ -188,6 +190,7 @@ def generate_page_summary(page: PageContent) -> str:
         ],
         **_temperature_kwargs(model, 0.2),
     )
+    logger.debug("Received response from OpenAI API for %s", page.url)
     content = response.choices[0].message.content or ""
     logger.info(
         "Generated LLM summary for %s in %.2fs",

--- a/app/scrape.py
+++ b/app/scrape.py
@@ -22,6 +22,7 @@ def fetch_page(url: str) -> Optional[tuple[str, str]]:
     robots.txt directives that would otherwise block crawling.
     """
 
+    logger.info("Starting fetch_page for %s (timeout=%ds)", url, REQUEST_TIMEOUT)
     try:
         response = requests.get(
             url,
@@ -29,6 +30,7 @@ def fetch_page(url: str) -> Optional[tuple[str, str]]:
             timeout=REQUEST_TIMEOUT,
             allow_redirects=True,
         )
+        logger.debug("Received response for %s with status %d", url, response.status_code)
     except requests.RequestException as exc:
         logger.warning("Failed to fetch %s: %s", url, exc)
         return None
@@ -38,11 +40,13 @@ def fetch_page(url: str) -> Optional[tuple[str, str]]:
         return None
 
     final_url = str(response.url)
+    logger.info("Successfully fetched %s (final URL: %s, content length: %d bytes)", url, final_url, len(response.text))
     return final_url, response.text
 
 
 def extract_page_content(url: str, html: str) -> PageContent:
     """Parse HTML content and extract text snippets for LLM consumption."""
+    logger.debug("Starting extract_page_content for %s", url)
     soup = BeautifulSoup(html, "html.parser")
 
     title_tag = soup.find("title")
@@ -68,6 +72,7 @@ def extract_page_content(url: str, html: str) -> PageContent:
     visible_text = " ".join(text_chunks)
     excerpt = visible_text[:2000]
 
+    logger.debug("Extracted page content for %s: title=%s, h1_count=%d, h2_count=%d", url, title, len(h1s), len(h2s))
     return PageContent(
         url=url,
         title=title,


### PR DESCRIPTION
## Summary
- Added detailed logging throughout the landing page processing pipeline
- Track thread pool execution with progress counters
- Log each step of page fetching, parsing, and LLM summarization
- Added exception logging with full stack traces

## Changes
- `app/main.py`: Enhanced logging in analyze endpoint and landing page processing
- `app/scrape.py`: Added logging to fetch_page and extract_page_content
- `app/llm.py`: Added logging before/after OpenAI API calls

This will help diagnose where the application hangs during the "analyzing landing pages" phase.

Fixes #75

🤖 Generated with [Claude Code](https://claude.ai/code)