### PR TITLE
Fix sign-in issue by committing session after customer sync

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -214,6 +214,7 @@ def oauth_callback(request: Request, session: Session = Depends(get_session)) ->
         client = build_google_ads_client(user)
         service = GoogleAdsService(client)
         sync_customers(session, user, service)
+        session.commit()
     except GoogleAdsOAuthError as exc:
         session.rollback()
         logger.exception("Failed to sync Google Ads accounts: %s", exc)


### PR DESCRIPTION
## Summary

Fixed the sign-in issue where users would get "Unknown customer ID" error after successful OAuth authentication.

## Changes

- Added explicit `session.commit()` after `sync_customers()` in the OAuth callback handler
- This ensures customer data is persisted to the database before redirecting to /campaigns

## Root Cause

The OAuth callback was successfully syncing customers from Google Ads, but the database transaction wasn't committed before redirecting. This created a race condition where the /campaigns endpoint would query for customers before they were actually saved, resulting in the 404 error.

Fixes #84

Generated with [Claude Code](https://claude.ai/code)