### PR TITLE
Fix /campaigns 404 error by allowing multiple users per customer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -289,7 +289,10 @@ def sync_customers(session: Session, user: User, service: GoogleAdsService) -> N
             logger.debug("Failed to hydrate customer %s: %s", resource_name, exc)
 
         existing = session.execute(
-            select(GoogleAdsCustomer).where(GoogleAdsCustomer.resource_name == resource_name)
+            select(GoogleAdsCustomer).where(
+                GoogleAdsCustomer.resource_name == resource_name,
+                GoogleAdsCustomer.user_id == user.id
+            )
         ).scalar_one_or_none()
         if existing:
             customer = existing

--- a/app/models.py
+++ b/app/models.py
@@ -53,7 +53,7 @@ class GoogleAdsCustomer(TimestampMixin, Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
-    resource_name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    resource_name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     customer_id: Mapped[str] = mapped_column(String(32), index=True, nullable=False)
     descriptive_name: Mapped[Optional[str]] = mapped_column(String(255))
     currency_code: Mapped[Optional[str]] = mapped_column(String(10))


### PR DESCRIPTION
Fixed a bug where users would get a 404 error when accessing the /campaigns page after OAuth login.

## Changes
- Removed unique constraint on GoogleAdsCustomer.resource_name
- Updated sync_customers to filter by both resource_name AND user_id
- Each user now gets their own copy of customer records

Fixes #86

Generated with [Claude Code](https://claude.ai/code)