### PR TITLE
Fix login UNIQUE constraint error on customer sync

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -290,12 +290,13 @@ def sync_customers(session: Session, user: User, service: GoogleAdsService) -> N
 
         existing = session.execute(
             select(GoogleAdsCustomer).where(
-                GoogleAdsCustomer.resource_name == resource_name,
-                GoogleAdsCustomer.user_id == user.id
+                GoogleAdsCustomer.resource_name == resource_name
             )
         ).scalar_one_or_none()
         if existing:
             customer = existing
+            # Update user association if it changed
+            customer.user_id = user.id
         else:
             customer = GoogleAdsCustomer(
                 user_id=user.id,


### PR DESCRIPTION
Fixed IntegrityError that occurred during OAuth callback when syncing Google Ads customers. The issue happened when retry login attempts tried to insert customers that already existed in the database.

The root cause was querying for existing customers using both resource_name AND user_id, while the database has a UNIQUE constraint only on resource_name. This meant existing customers weren't found on retry, causing INSERT failures.

Changed the query to check for existing customers by resource_name only. If a customer exists, we now update the user_id association instead of attempting a duplicate insert.

Fixes #88

Generated with [Claude Code](https://claude.ai/code)