### PR TITLE
Fix campaign segmentation logic to correctly categorize REMOVED campaigns

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -431,7 +431,7 @@ async def list_campaigns(
             active_campaigns.append(campaign)
         elif status_value in {"PAUSED", "PENDING"}:
             paused_campaigns.append(campaign)
-        else:
+        elif status_value == "REMOVED":
             archived_campaigns.append(campaign)
 
     sort_key = lambda c: (c.get("name") or "").lower()


### PR DESCRIPTION
Previously, all campaigns with status other than ENABLED, PAUSED, or PENDING were incorrectly grouped into the "Archived" bucket due to an overly broad else clause. This caused active, paused, and removed campaigns to all appear mixed together in the archived section.

Changed the logic to explicitly check for REMOVED status only, ensuring campaigns are properly categorized:
- Active: ENABLED campaigns
- Paused: PAUSED and PENDING campaigns
- Archived: REMOVED campaigns only

Fixes #92

Generated with [Claude Code](https://claude.ai/code)