### PR TITLE
Fix campaign segmentation by properly extracting enum names from Google Ads API

### DIFF
--- a/app/google_ads_client.py
+++ b/app/google_ads_client.py
@@ -423,8 +423,8 @@ class GoogleAdsService:
                         campaign_id=str(campaign.id),
                         name=str(campaign.name),
                         customer_id=customer_id,
-                        status=str(campaign.status),
-                        advertising_channel_type=str(campaign.advertising_channel_type),
+                        status=campaign.status.name if hasattr(campaign.status, 'name') else str(campaign.status),
+                        advertising_channel_type=campaign.advertising_channel_type.name if hasattr(campaign.advertising_channel_type, 'name') else str(campaign.advertising_channel_type),
                     )
                 )
             logger.info(


### PR DESCRIPTION
Previously, campaign statuses were being converted using str() which returned numeric values (e.g., "2" for ENABLED) instead of the enum names. This caused the segmentation logic in main.py to fail all comparisons, resulting in NO campaigns being added to any bucket (active, paused, or archived).

Changed to use .name attribute to extract the actual enum name (e.g., "ENABLED", "PAUSED") which properly matches the segmentation logic expectations.

Also fixed advertising_channel_type to use the same pattern for consistency.

Fixes #92

---

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/andrew99666/super-duper-umbrella/actions/runs/18914941108) • [`claude/issue-92-20251029-1623`](https://github.com/andrew99666/super-duper-umbrella/tree/claude/issue-92-20251029-1623