### PR TITLE
Fix database migration for manager_customer_id column

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
@@ -49,12 +49,44 @@ engine = create_engine(DATABASE_URL, connect_args=connect_args, future=True)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session, future=True)
 
 
+def _migrate_schema() -> None:
+    """Apply schema migrations for existing databases.
+
+    This function handles adding new columns to existing tables that were created
+    before the column was added to the model. It's a lightweight alternative to
+    full Alembic migrations for simple schema changes.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    # Only perform migrations for SQLite databases
+    if not url.drivername.startswith("sqlite"):
+        return
+
+    with engine.connect() as conn:
+        # Check if manager_customer_id column exists in customers table
+        result = conn.execute(
+            text("SELECT COUNT(*) FROM pragma_table_info('customers') WHERE name='manager_customer_id'")
+        )
+        column_exists = result.scalar() > 0
+
+        if not column_exists:
+            logger.info("Adding manager_customer_id column to customers table")
+            conn.execute(text("ALTER TABLE customers ADD COLUMN manager_customer_id VARCHAR(32)"))
+            conn.commit()
+            logger.info("Successfully added manager_customer_id column")
+
+
 def init_db() -> None:
-    """Create all tables."""
+    """Create all tables and apply necessary migrations."""
     # Import models within the function to avoid circular imports.
     from . import models  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
+
+    # Apply schema migrations for existing databases
+    _migrate_schema()
 
 
 @contextmanager


### PR DESCRIPTION
### Summary
Fixed the `sqlite3.OperationalError: no such column: customers.manager_customer_id` error by adding automatic database schema migration.

### Changes
- Added `_migrate_schema()` function in `app/db.py` that automatically detects and adds missing columns
- The migration runs at startup and logs when columns are added
- Works for existing databases without requiring manual intervention

Fixes #97

🤖 Generated with [Claude Code](https://claude.ai/code)